### PR TITLE
Glowing items/totems + backpack pickup

### DIFF
--- a/src/main/java/vazkii/quark/base/asm/ASMHooks.java
+++ b/src/main/java/vazkii/quark/base/asm/ASMHooks.java
@@ -39,16 +39,14 @@ import vazkii.quark.automation.feature.ChainLinkage;
 import vazkii.quark.automation.feature.PistonsMoveTEs;
 import vazkii.quark.automation.feature.PistonsPushPullItems;
 import vazkii.quark.base.handler.QuarkPistonStructureHelper;
-import vazkii.quark.client.feature.BetterFireEffect;
-import vazkii.quark.client.feature.ItemsFlashBeforeExpiring;
-import vazkii.quark.client.feature.RenderItemsInChat;
-import vazkii.quark.client.feature.ShowInvalidSlots;
+import vazkii.quark.client.feature.*;
 import vazkii.quark.decoration.feature.IronLadders;
 import vazkii.quark.decoration.feature.MoreBannerLayers;
 import vazkii.quark.experimental.features.BetterNausea;
 import vazkii.quark.experimental.features.ColoredLights;
 import vazkii.quark.management.feature.BetterCraftShifting;
 import vazkii.quark.misc.feature.*;
+import vazkii.quark.oddities.feature.TotemOfHolding;
 import vazkii.quark.tweaks.feature.HoeSickle;
 import vazkii.quark.tweaks.feature.ImprovedSleeping;
 import vazkii.quark.tweaks.feature.SpringySlime;
@@ -267,6 +265,12 @@ public final class ASMHooks {
 	// ===== PARROT EGGS ==== //
 	public static ResourceLocation replaceParrotTexture(ResourceLocation previous, NBTTagCompound parrot) {
 		return ParrotEggs.getTextureForParrot(previous, parrot);
+	}
+
+	// ===== GLOWING ITEMS & TOTEMS OF HOLDING ==== //
+	@SideOnly(Side.CLIENT)
+	public static boolean isOutlineActive(Entity entity, Entity viewer) {
+		return GlowingItems.isOutlineActive(entity, viewer) || TotemOfHolding.isOutlineActive(entity, viewer);
 	}
 	
 }

--- a/src/main/java/vazkii/quark/client/QuarkClient.java
+++ b/src/main/java/vazkii/quark/client/QuarkClient.java
@@ -30,6 +30,7 @@ public class QuarkClient extends Module {
 		registerFeature(new EnchantedBooksShowItems());
 		registerFeature(new ShowInvalidSlots());
 		registerFeature(new RenderItemsInChat());
+		registerFeature(new GlowingItems(), false);
 	}
 	
 	@Override

--- a/src/main/java/vazkii/quark/client/feature/GlowingItems.java
+++ b/src/main/java/vazkii/quark/client/feature/GlowingItems.java
@@ -1,0 +1,50 @@
+package vazkii.quark.client.feature;
+
+import gnu.trove.set.TIntSet;
+import gnu.trove.set.hash.TIntHashSet;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+import vazkii.quark.base.module.Feature;
+import vazkii.quark.base.module.ModuleLoader;
+import vazkii.quark.base.util.ItemMetaHelper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class GlowingItems extends Feature {
+
+    public static double maxDistance;
+    public static final Map<ResourceLocation, TIntSet> glowingItems = new HashMap<>();
+
+    @Override
+    public void setupConfig() {
+        glowingItems.clear();
+        String[] tempGlowingItems = loadPropStringList("Glowing Items",
+                "Items that should glow when near the player\nFormat is modid:item[:meta]",
+                new String[0]);
+        for (ItemStack stack : ItemMetaHelper.getFromStringArray("glowing item", tempGlowingItems)) {
+            glowingItems.computeIfAbsent(stack.getItem().getRegistryName(), k -> new TIntHashSet())
+                    .add(stack.getMetadata());
+        }
+        maxDistance = loadPropDouble("Maximum Distance", "The maximum distance from the player at which items will glow. Default is 32 blocks", 32);
+    }
+
+    @SideOnly(Side.CLIENT)
+    public static boolean isOutlineActive(Entity entity, Entity viewer) {
+        if (!(entity instanceof EntityItem) || !ModuleLoader.isFeatureEnabled(GlowingItems.class)) {
+            return false;
+        }
+
+        ItemStack stack = ((EntityItem) entity).getItem();
+        if (stack.isEmpty()) return false;
+
+        TIntSet metas = glowingItems.get(stack.getItem().getRegistryName());
+        return metas != null && metas.contains(stack.getMetadata())
+                && viewer.getDistanceSq(entity) <= maxDistance * maxDistance;
+    }
+
+}

--- a/src/main/java/vazkii/quark/oddities/feature/Backpacks.java
+++ b/src/main/java/vazkii/quark/oddities/feature/Backpacks.java
@@ -1,8 +1,9 @@
 package vazkii.quark.oddities.feature;
 
-import java.util.Random;
+import java.util.*;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import baubles.api.BaublesApi;
 import net.minecraft.client.Minecraft;
@@ -11,28 +12,38 @@ import net.minecraft.client.gui.inventory.GuiInventory;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.IMerchant;
+import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.passive.EntityVillager;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Enchantments;
 import net.minecraft.init.Items;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.ItemStack;
+import net.minecraft.stats.StatList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.village.MerchantRecipe;
 import net.minecraft.village.MerchantRecipeList;
 import net.minecraftforge.client.event.GuiOpenEvent;
 import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.event.entity.player.EntityItemPickupEvent;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
+import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.PlayerEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent.ClientTickEvent;
 import net.minecraftforge.fml.common.registry.VillagerRegistry.VillagerCareer;
 import net.minecraftforge.fml.common.registry.VillagerRegistry.VillagerProfession;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import net.minecraftforge.items.IItemHandlerModifiable;
+import net.minecraftforge.items.ItemHandlerHelper;
 import vazkii.arl.network.NetworkHandler;
 import vazkii.arl.recipe.RecipeHandler;
+import vazkii.arl.util.InventoryIIH;
 import vazkii.quark.base.module.Feature;
 import vazkii.quark.base.network.message.MessageHandleBackpack;
 import vazkii.quark.oddities.RecipesBackpackDyes;
@@ -43,17 +54,21 @@ public class Backpacks extends Feature {
 
 	public static ItemBackpack backpack;
 	
-	public static boolean superOpMode, enableTrades, enableCrafting;
+	public static boolean superOpMode, enableTrades, enableCrafting, enablePickUp;
 
 	public static  int leatherCount, minEmeralds, maxEmeralds;
 	
 	@SideOnly(Side.CLIENT)
 	public static boolean backpackRequested;
+
+	private final Map<UUID, PickUpTask> pickUpQueue = new HashMap<>();
+	private boolean processingPickUpQueue = false;
 	
 	@Override
 	public void setupConfig() {
 		enableTrades = loadPropBool("Enable Trade", "Set this to false if you want to disable the villager trade so you can add an alternate acquisition method", true);
 		enableCrafting = loadPropBool("Enable Crafting", "Set this to true to enable a crafting recipe", false);
+		enablePickUp = loadPropBool("Enable Backpack Pick-Up", "Set this to true to allow items to be picked up into backpacks when the main inventory is full", false);
 		superOpMode = loadPropBool("Unbalanced Mode", "Set this to true to allow the backpacks to be unequipped even with items in them", false);
 		leatherCount = loadPropInt("Required Leather", "", 12);
 		minEmeralds = loadPropInt("Min Required Emeralds", "", 12);
@@ -123,6 +138,65 @@ public class Backpacks extends Feature {
 					return;
 				}
 	}
+
+	@SubscribeEvent(priority = EventPriority.LOWEST)
+	public void preItemPickUp(EntityItemPickupEvent event) {
+		if (!enablePickUp || processingPickUpQueue) return;
+
+		EntityItem item = event.getItem();
+		if (item.isDead || item.getItem().isEmpty()) return;
+
+		EntityPlayer player = event.getEntityPlayer();
+		if (!isEntityWearingBackpack(player)) return;
+
+		pickUpQueue.computeIfAbsent(item.getUniqueID(), k -> new PickUpTask(item)).players.add(player);
+	}
+
+	@SubscribeEvent(priority = EventPriority.LOWEST)
+	public void postItemPickUp(PlayerEvent.ItemPickupEvent event) {
+		if (!enablePickUp || processingPickUpQueue) return;
+
+		EntityItem item = event.getOriginalEntity();
+		if (item.isDead || item.getItem().isEmpty())
+			pickUpQueue.remove(item.getUniqueID());
+	}
+
+	@SubscribeEvent
+	public void onServerTickEnd(TickEvent.ServerTickEvent event) {
+		if (!enablePickUp || event.phase != TickEvent.Phase.END) return;
+
+		processingPickUpQueue = true;
+		try {
+			for (PickUpTask task : pickUpQueue.values()) {
+				for (EntityPlayer player : task.players) {
+					if (task.item.isDead) break;
+					ItemStack stack = task.item.getItem();
+					if (stack.isEmpty()) break;
+					IItemHandlerModifiable inv = getBackpackInventory(player);
+					if (inv == null) continue;
+
+					ItemStack original = stack.copy();
+					ItemStack remainder = ItemHandlerHelper.insertItemStacked(inv, stack, false);
+					if (remainder.getCount() >= original.getCount()) continue; // nothing was transferred
+
+					task.item.setItem(remainder);
+					ItemStack transferred = ItemHandlerHelper.copyStackWithSize(original, original.getCount() - remainder.getCount());
+					FMLCommonHandler.instance().firePlayerItemPickupEvent(player, task.item, transferred);
+
+					player.addStat(StatList.getObjectsPickedUpStats(original.getItem()), transferred.getCount());
+					if (task.item.getItem().isEmpty()) {
+						player.onItemPickup(task.item, transferred.getCount());
+						task.item.setDead();
+						// vanilla code resets the entity's stack to its original count here; it's unclear why this would be useful
+						break;
+					}
+				}
+			}
+			pickUpQueue.clear();
+		} finally {
+			processingPickUpQueue = false;
+		}
+	}
 	
 	@SideOnly(Side.CLIENT)
 	private static boolean isInventoryGUI(GuiScreen gui) {
@@ -162,6 +236,19 @@ public class Backpacks extends Feature {
 		
 		return false;
 	}
+
+	@Nullable
+	public static IItemHandlerModifiable getBackpackInventory(Entity e) {
+		ItemStack stack = null;
+		if (Loader.isModLoaded("baubles")) {
+			if (e instanceof EntityPlayer)
+				stack = BaublesApi.getBaublesHandler((EntityPlayer) e).getStackInSlot(5);
+		} else {
+			if (e instanceof EntityLivingBase)
+				stack = ((EntityLivingBase) e).getItemStackFromSlot(EntityEquipmentSlot.CHEST);
+		}
+		return stack != null && stack.getItem() == backpack ? new InventoryIIH(stack) : null;
+	}
 	
 	@Override
 	public boolean requiresMinecraftRestartToEnable() {
@@ -181,5 +268,16 @@ public class Backpacks extends Feature {
 			recipeList.add(new MerchantRecipe(new ItemStack(Items.LEATHER, leatherCount), new ItemStack(Items.EMERALD, emeraldCount), new ItemStack(backpack)));
 		}
 	}
+
+	private static class PickUpTask {
+
+		final EntityItem item;
+		final List<EntityPlayer> players = new ArrayList<>();
+
+        PickUpTask(EntityItem item) {
+            this.item = item;
+        }
+
+    }
 
 }

--- a/src/main/java/vazkii/quark/oddities/feature/TotemOfHolding.java
+++ b/src/main/java/vazkii/quark/oddities/feature/TotemOfHolding.java
@@ -57,6 +57,7 @@ public class TotemOfHolding extends Feature {
 	
 	public static boolean darkSoulsMode, enableOnPK, destroyItems, anyoneCollect, enableSoulCompass, shouldBlacklistBeWhitelist, enableTotemItem;
 	public static float entityScale;
+	public static double glowRange;
 
 	private static String[] tempBlacklist;
 	public static Set<Pair<Item, Integer>> holdingBlacklist;
@@ -79,6 +80,7 @@ public class TotemOfHolding extends Feature {
 		tempSavingItem = loadPropString("Saving Item", "An item that must be in the player inventory for the totem to work. Set to 'none' to disable", "quark:totem_of_holding");
 		enableTotemItem = loadPropBool("Enable Totem of Holding Item", "", true);
 		entityScale = (float) loadPropDouble("Totem of Holding Entity Scale", "Displayed scale of the totem of holding entity", 1.0D);
+		glowRange = loadPropDouble("Totem Glow Range", "Maximum range at which totems visibly glow. Default is 32; set to 0 to disable", 32);
 	}
 	
 	@Override
@@ -213,6 +215,12 @@ public class TotemOfHolding extends Feature {
 		}
 		
 		return new BlockPos(0, -1, 0);
+	}
+
+	@SideOnly(Side.CLIENT)
+	public static boolean isOutlineActive(Entity entity, Entity viewer) {
+		return glowRange > 0 && entity instanceof EntityTotemOfHolding
+				&& viewer.getDistanceSq(entity) <= glowRange * glowRange;
 	}
 	
 	@Override

--- a/src/main/java/vazkii/quark/oddities/inventory/ContainerBackpack.java
+++ b/src/main/java/vazkii/quark/oddities/inventory/ContainerBackpack.java
@@ -1,12 +1,10 @@
 package vazkii.quark.oddities.inventory;
 
-import baubles.api.BaublesApi;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.*;
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.fml.common.Loader;
-import vazkii.arl.util.InventoryIIH;
+import net.minecraftforge.items.IItemHandlerModifiable;
 import vazkii.quark.oddities.feature.Backpacks;
 
 import javax.annotation.Nonnull;
@@ -24,19 +22,9 @@ public class ContainerBackpack extends ContainerPlayer {
 		Slot anchor = inventorySlots.get(9);
 		int left = anchor.xPos;
 		int top = anchor.yPos - 58;
-		
-		ItemStack backpack;
-		if (Loader.isModLoaded("baubles"))
-			backpack = BaublesApi.getBaublesHandler(player).getStackInSlot(5);
-		else
-			backpack = player.inventory.armorInventory.get(2);
 
-		if (backpack != null && backpack.getItem() != Backpacks.backpack)
-			backpack = null;
-
-		if (backpack != null) {
-			InventoryIIH inv = new InventoryIIH(backpack);
-			
+		IItemHandlerModifiable inv = Backpacks.getBackpackInventory(player);
+		if (inv != null) {
 			for (int i = 0; i < 3; ++i) {
 				for (int j = 0; j < 9; ++j) {
 					int k = j + i * 9;


### PR DESCRIPTION
This PR:
* Adds a "glowing items" feature to the client module, which allows you to configure a list of items that should have the glowing effect applied when near the player
* Adds a "glowing totems" option to the totem of holding feature, which allows you to make totems of holding glow when near the player
* Adds a "backpack pickup" option to the backpacks feature, which allows dropped items to be picked up into an equipped backpack when the main inventory is full
* Fixes various issues with Quark's item inventory code (which is used by backpacks for their internal inventory)