### PR TITLE
Backpack z-fighting fix plus a few options

### DIFF
--- a/src/main/java/vazkii/quark/oddities/client/model/ModelBackpack.java
+++ b/src/main/java/vazkii/quark/oddities/client/model/ModelBackpack.java
@@ -21,7 +21,7 @@ public class ModelBackpack extends ModelModArmor {
 
 		straps = new ModelRenderer(this, 24, 0);
 		straps.setRotationPoint(0.0F, 0.0F, 0.0F);
-		straps.addBox(-4.0F, 0.05F, -3.0F, 8, 8, 5, 0.0F);
+		straps.addBox(-4.0F, 0.05F, -3.01F, 8, 8, 5, 0.0F);
 		fitting = new ModelRenderer(this, 50, 0);
 		fitting.setRotationPoint(0.0F, 0.0F, 0.0F);
 		fitting.addBox(-1.0F, 3.0F, 6.0F, 2, 3, 1, 0.0F);

--- a/src/main/java/vazkii/quark/oddities/feature/Backpacks.java
+++ b/src/main/java/vazkii/quark/oddities/feature/Backpacks.java
@@ -54,7 +54,7 @@ public class Backpacks extends Feature {
 
 	public static ItemBackpack backpack;
 	
-	public static boolean superOpMode, enableTrades, enableCrafting, enablePickUp;
+	public static boolean superOpMode, enableTrades, enableCrafting, enablePickUp, ignoreShiftClick;
 
 	public static  int leatherCount, minEmeralds, maxEmeralds;
 	
@@ -70,6 +70,7 @@ public class Backpacks extends Feature {
 		enableCrafting = loadPropBool("Enable Crafting", "Set this to true to enable a crafting recipe", false);
 		enablePickUp = loadPropBool("Enable Backpack Pick-Up", "Set this to true to allow items to be picked up into backpacks when the main inventory is full", false);
 		superOpMode = loadPropBool("Unbalanced Mode", "Set this to true to allow the backpacks to be unequipped even with items in them", false);
+		ignoreShiftClick = loadPropBool("Backpack Ignores Shift-Clicking", "Set this to true to make shift-clicking inventory items send them to the hotbar instead of the backpack", false);
 		leatherCount = loadPropInt("Required Leather", "", 12);
 		minEmeralds = loadPropInt("Min Required Emeralds", "", 12);
 		maxEmeralds = loadPropInt("Max Required Emeralds", "", 18);

--- a/src/main/java/vazkii/quark/oddities/feature/Backpacks.java
+++ b/src/main/java/vazkii/quark/oddities/feature/Backpacks.java
@@ -44,17 +44,19 @@ import net.minecraftforge.items.ItemHandlerHelper;
 import vazkii.arl.network.NetworkHandler;
 import vazkii.arl.recipe.RecipeHandler;
 import vazkii.arl.util.InventoryIIH;
+import vazkii.quark.base.module.ConfigHelper;
 import vazkii.quark.base.module.Feature;
 import vazkii.quark.base.network.message.MessageHandleBackpack;
 import vazkii.quark.oddities.RecipesBackpackDyes;
 import vazkii.quark.oddities.client.gui.GuiBackpackInventory;
 import vazkii.quark.oddities.item.ItemBackpack;
+import vazkii.quark.oddities.item.ItemBackpackBaubles;
 
 public class Backpacks extends Feature {
 
 	public static ItemBackpack backpack;
 	
-	public static boolean superOpMode, enableTrades, enableCrafting, enablePickUp, ignoreShiftClick;
+	public static boolean superOpMode, enableTrades, enableCrafting, enablePickUp, ignoreShiftClick, enableBaubles;
 
 	public static  int leatherCount, minEmeralds, maxEmeralds;
 	
@@ -74,11 +76,12 @@ public class Backpacks extends Feature {
 		leatherCount = loadPropInt("Required Leather", "", 12);
 		minEmeralds = loadPropInt("Min Required Emeralds", "", 12);
 		maxEmeralds = loadPropInt("Max Required Emeralds", "", 18);
+		if (Loader.isModLoaded("baubles")) enableBaubles = loadPropBool("Enable Backpack Bauble", "Set this to true to turn the backpack into a bauble that's equipped in the Body slot", true);
 	}
 	
 	@Override
 	public void preInit(FMLPreInitializationEvent event) {
-		backpack = new ItemBackpack();
+		backpack = ((Loader.isModLoaded("baubles") && enableBaubles) ? new ItemBackpackBaubles() : new ItemBackpack());
 		
 		if (enableCrafting)
 			RecipeHandler.addOreDictRecipe(new ItemStack(backpack),

--- a/src/main/java/vazkii/quark/oddities/feature/TotemOfHolding.java
+++ b/src/main/java/vazkii/quark/oddities/feature/TotemOfHolding.java
@@ -78,7 +78,7 @@ public class TotemOfHolding extends Feature {
 				"Format is modid:item[:meta]", 
 				new String[0]);
 		tempSavingItem = loadPropString("Saving Item", "An item that must be in the player inventory for the totem to work. Set to 'none' to disable", "quark:totem_of_holding");
-		enableTotemItem = loadPropBool("Enable Totem of Holding Item", "", true);
+		enableTotemItem = loadPropBool("Enable Totem of Holding Item", "", false);
 		entityScale = (float) loadPropDouble("Totem of Holding Entity Scale", "Displayed scale of the totem of holding entity", 1.0D);
 		glowRange = loadPropDouble("Totem Glow Range", "Maximum range at which totems visibly glow. Default is 32; set to 0 to disable", 32);
 	}
@@ -118,6 +118,7 @@ public class TotemOfHolding extends Feature {
 				.collect(Collectors.toSet());
 		
 		ItemStack item = (tempSavingItem.equals("none") ? ItemStack.EMPTY : new ArrayList<>(ItemMetaHelper.getFromString("totem holding saving item", tempSavingItem, false)).get(0));
+		if (tempSavingItem.equals("quark:totem_of_holding") && !enableTotemItem) item = ItemStack.EMPTY;
 		savingItem = !item.isEmpty() ? Pair.of(item.getItem(), item.getMetadata()) : Pair.of(Items.AIR, 0);
 	}
 	

--- a/src/main/java/vazkii/quark/oddities/inventory/ContainerBackpack.java
+++ b/src/main/java/vazkii/quark/oddities/inventory/ContainerBackpack.java
@@ -3,8 +3,12 @@ package vazkii.quark.oddities.inventory;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.*;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.items.IItemHandlerModifiable;
+import vazkii.aurelienribon.tweenengine.equations.Back;
+import vazkii.quark.base.module.ConfigHelper;
+import vazkii.quark.oddities.QuarkOddities;
 import vazkii.quark.oddities.feature.Backpacks;
 
 import javax.annotation.Nonnull;
@@ -161,6 +165,11 @@ public class ContainerBackpack extends ContainerPlayer {
 	@Nonnull
 	@Override
 	public ItemStack slotClick(int slotId, int dragType, ClickType clickTypeIn, EntityPlayer player) {
+		if (Backpacks.ignoreShiftClick && clickTypeIn == ClickType.QUICK_MOVE && slotId < 36)
+		{
+			return player.inventoryContainer.slotClick(slotId, dragType, clickTypeIn, player);
+		}
+
 		SlotCachingItemHandler.cache(this);
 		ItemStack stack = super.slotClick(slotId, dragType, clickTypeIn, player);
 		SlotCachingItemHandler.applyCache(this);

--- a/src/main/java/vazkii/quark/oddities/item/ItemBackpackBaubles.java
+++ b/src/main/java/vazkii/quark/oddities/item/ItemBackpackBaubles.java
@@ -1,0 +1,131 @@
+package vazkii.quark.oddities.item;
+
+import baubles.api.BaubleType;
+import baubles.api.BaublesApi;
+import baubles.api.IBauble;
+import baubles.api.cap.IBaublesItemHandler;
+import baubles.api.render.IRenderBauble;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.model.ModelPlayer;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.EntityEquipmentSlot;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.EnumActionResult;
+import net.minecraft.util.EnumHand;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.Optional;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+import vazkii.quark.oddities.client.model.ModelBackpack;
+import vazkii.quark.oddities.feature.Backpacks;
+
+import static vazkii.quark.oddities.feature.Backpacks.backpack;
+
+@Optional.InterfaceList(value = {
+        @Optional.Interface(iface = "baubles.api.IBauble", modid = "baubles", striprefs = true),
+        @Optional.Interface(iface = "baubles.api.render.IRenderBauble", modid = "baubles", striprefs = true)
+})
+public class ItemBackpackBaubles extends ItemBackpack implements IBauble, IRenderBauble {
+
+    @Override
+    public ActionResult<ItemStack> onItemRightClick(World world, EntityPlayer player, EnumHand hand) {
+        ItemStack stack = player.getHeldItem(hand);
+        if (!world.isRemote) {
+            IBaublesItemHandler baubles = BaublesApi.getBaublesHandler(player);
+            for (int i = 0; i < baubles.getSlots(); i++) {
+                if ((baubles.getStackInSlot(i) == null || baubles.getStackInSlot(i).isEmpty())
+                        && baubles.isItemValidForSlot(i, stack, player)) {
+                    baubles.setStackInSlot(i, stack.copy());
+                    if (!player.capabilities.isCreativeMode) {
+                        player.inventory.setInventorySlotContents(player.inventory.currentItem, ItemStack.EMPTY);
+                    }
+                    onEquipped(stack, player);
+
+                    return new ActionResult<ItemStack>(EnumActionResult.SUCCESS, stack);
+                }
+            }
+            return new ActionResult<ItemStack>(EnumActionResult.FAIL, stack);
+        }
+        return new ActionResult<ItemStack>(EnumActionResult.SUCCESS, stack);
+    }
+
+    @Override
+    @Optional.Method(modid = "baubles")
+    public BaubleType getBaubleType(ItemStack itemStack) {
+        return BaubleType.BODY;
+    }
+
+    @Override
+    @Optional.Method(modid = "baubles")
+    public boolean canEquip(ItemStack itemstack, EntityLivingBase player) {
+        return !Backpacks.isEntityWearingBackpack(player, itemstack);
+    }
+
+    @Override
+    @Optional.Method(modid = "baubles")
+    public boolean canUnequip(ItemStack itemstack, EntityLivingBase player) {
+        return Backpacks.superOpMode || !doesBackpackHaveItems(itemstack);
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    @Optional.Method(modid = "baubles")
+    public void onPlayerBaubleRender(ItemStack itemStack, EntityPlayer player, RenderType renderType, float v) {
+        if (!player.world.isRemote) return;
+
+        if (renderType != RenderType.BODY) return;
+
+        if (model == null) model = new ModelBackpack();
+
+        model.setModelAttributes(new ModelPlayer(0.0F, false));
+
+        Minecraft.getMinecraft().renderEngine.bindTexture(WORN_TEXTURE_RL);
+
+        int i = backpack.getColor(itemStack);
+        float red = (float) (i >> 16 & 255) / 255.0F;
+        float green = (float) (i >> 8 & 255) / 255.0F;
+        float blue = (float) (i & 255) / 255.0F;
+
+        GlStateManager.color(red, green, blue, 1);
+
+
+        float partialTicks = Minecraft.getMinecraft().getRenderPartialTicks();
+        float f = this.interpolateRotation(player.prevRenderYawOffset, player.renderYawOffset, partialTicks);
+        float f1 = this.interpolateRotation(player.prevRotationYawHead, player.rotationYawHead, partialTicks);
+        float f2 = f1 - f;
+//		float f4 = renderer.prepareScale(player, Minecraft.getMinecraft().getRenderPartialTicks());
+        float f4 = 0.0625F;
+        float f8 = (float) player.ticksExisted + partialTicks;
+        float f5 = player.prevLimbSwingAmount + (player.limbSwingAmount - player.prevLimbSwingAmount) * partialTicks;
+        float f6 = player.limbSwing - player.limbSwingAmount * (1.0F - partialTicks);
+        float f7 = player.prevRotationPitch + (player.rotationPitch - player.prevRotationPitch) * partialTicks;
+
+        model.setVisible(false);
+        model.bipedBody.showModel = true;
+
+        model.render(player, f6, f5, f8, f2, f7, f4);
+
+        Minecraft.getMinecraft().renderEngine.bindTexture(WORN_OVERLAY_TEXTURE_RL);
+
+        GlStateManager.color(1, 1, 1, 1);
+
+        model.render(player, 0, 0, 1000, 0, 0, 0.0625F);
+    }
+
+    @Override
+    public EntityEquipmentSlot getEquipmentSlot() {
+        return null;
+    }
+
+    @Override
+    public boolean isValidArmor(ItemStack stack, EntityEquipmentSlot armorType, Entity entity) {
+        if (stack.getItem() instanceof ItemBackpack && entity instanceof EntityPlayer) {
+            return false;
+        }
+        return super.isValidArmor(stack, armorType, entity);
+    }
+}


### PR DESCRIPTION
- Fixed backpacks z-fighting chestplates when using the Baubles version of the item
- The Totem of Holding is now disabled by default, mainly to avoid modpack creators unknowingly keeping that option enabled after switching to RotN edition
- Added an option to enabled/disable the backpack being equipped in a Baubles slot (option only added when Baubles is installed)
- Added an option to make it so shift-clicking in items in your inventory sends them to your hotbar instead of the backpack's container