### PR TITLE
Add LemonSkin to incompatible mods on Food Tooltips

### DIFF
--- a/src/main/java/vazkii/quark/client/feature/FoodTooltip.java
+++ b/src/main/java/vazkii/quark/client/feature/FoodTooltip.java
@@ -101,7 +101,7 @@ public class FoodTooltip extends Feature {
 
 	@Override
 	public String[] getIncompatibleMods() {
-		return new String[] { "appleskin" };
+		return new String[] { "appleskin", "lemonskin" };
 	}
 
 	@Override


### PR DESCRIPTION
Despite LemonSkin being a fork of AppleSkin which is already marked as incompatible here. It uses a different mod id (something which forks should NOT be doing!).